### PR TITLE
GUACAMOLE-273: Add Brazil keymap for RDP

### DIFF
--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -72,6 +72,7 @@
                         "it-it-qwerty",
                         "ja-jp-qwerty",
                         "sv-se-qwerty",
+                        "pt-br-qwerty",
                         "failsafe"
                     ]
                 },


### PR DESCRIPTION
Added option to choose Brazilian Portuguese keyboard layout under RDP keyboard server-layout.