### PR TITLE
GUACAMOLE-273: Add Brazillian keymap for RDP

### DIFF
--- a/guacamole/src/main/webapp/translations/en.json
+++ b/guacamole/src/main/webapp/translations/en.json
@@ -383,6 +383,7 @@
         "FIELD_OPTION_SERVER_LAYOUT_IT_IT_QWERTY" : "Italian (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_JA_JP_QWERTY" : "Japanese (Qwerty)",
         "FIELD_OPTION_SERVER_LAYOUT_SV_SE_QWERTY" : "Swedish (Qwerty)",
+        "FIELD_OPTION_SERVER_LAYOUT_PT_BR_QWERTY"  : "BR Portuguese (Qwerty)",
 
         "NAME" : "RDP",
 


### PR DESCRIPTION
included translation for PT_BR_QWERY RDP server keyboard layout.